### PR TITLE
Implement Honey behavior for Honey-Slabs, -Stairs and -Walls

### DIFF
--- a/src/main/java/games/twinhead/moreslabsstairsandwalls/block/ModBlocks.java
+++ b/src/main/java/games/twinhead/moreslabsstairsandwalls/block/ModBlocks.java
@@ -477,6 +477,8 @@ public enum ModBlocks {
                 .hardness(block.getHardness())
                 .resistance(block.getBlastResistance())
                 .slipperiness(block.getSlipperiness())
+                .jumpVelocityMultiplier(block.getJumpVelocityMultiplier())
+                .velocityMultiplier(block.getVelocityMultiplier())
                 ;
 
         if (!block.getDefaultState().isOpaque()){

--- a/src/main/java/games/twinhead/moreslabsstairsandwalls/block/honey/HoneySlab.java
+++ b/src/main/java/games/twinhead/moreslabsstairsandwalls/block/honey/HoneySlab.java
@@ -63,11 +63,16 @@ public class HoneySlab extends TranslucentSlab {
         super.onEntityCollision(state, world, pos, entity);
     }
 
-    public static boolean isSliding(BlockPos pos, Entity entity) {
+    private boolean isSliding(BlockPos pos, Entity entity) {
         if (entity.isOnGround()) {
             return false;
         }
-        if (entity.getY() > (double)pos.getY() + 0.9375 - 1.0E-7) {
+        SlabType slabType = entity.getWorld().getBlockState(pos).get(TYPE);
+        double maxY = switch (slabType) {
+            case DOUBLE, TOP -> 0.9375;
+            default -> 0.4375;
+        };
+        if (entity.getY() > (double)pos.getY() + maxY - 1.0E-7) {
             return false;
         }
         if (entity.getVelocity().y >= -0.08) {

--- a/src/main/java/games/twinhead/moreslabsstairsandwalls/block/honey/HoneySlab.java
+++ b/src/main/java/games/twinhead/moreslabsstairsandwalls/block/honey/HoneySlab.java
@@ -1,0 +1,109 @@
+package games.twinhead.moreslabsstairsandwalls.block.honey;
+
+import games.twinhead.moreslabsstairsandwalls.block.ModBlocks;
+import games.twinhead.moreslabsstairsandwalls.block.translucent.TranslucentSlab;
+import net.minecraft.advancement.criterion.Criteria;
+import net.minecraft.block.*;
+import net.minecraft.block.enums.SlabType;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityStatuses;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.TntEntity;
+import net.minecraft.entity.vehicle.AbstractMinecartEntity;
+import net.minecraft.entity.vehicle.BoatEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.world.BlockView;
+import net.minecraft.world.World;
+
+public class HoneySlab extends TranslucentSlab {
+
+    protected static final VoxelShape FULL_SHAPE = Block.createCuboidShape(1.0, 0.0, 1.0, 15.0, 15.0, 15.0);
+    public static final VoxelShape BOTTOM_SHAPE = Block.createCuboidShape(1.0, 0.0, 1.0, 15.0, 7.0, 15.0);
+    public static final VoxelShape TOP_SHAPE = Block.createCuboidShape(1.0, 8.0, 1.0, 15.0, 15.0, 15.0);
+
+    public HoneySlab(Settings settings) {
+        super(ModBlocks.HONEY_BLOCK, settings);
+    }
+
+    public static boolean hasHoneyBlockEffects(Entity entity) {
+        return entity instanceof LivingEntity || entity instanceof AbstractMinecartEntity || entity instanceof TntEntity || entity instanceof BoatEntity;
+    }
+
+    @Override
+    public VoxelShape getCollisionShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
+        SlabType slabType = state.get(TYPE);
+        return switch (slabType) {
+            case DOUBLE -> FULL_SHAPE;
+            case TOP -> TOP_SHAPE;
+            default -> BOTTOM_SHAPE;
+        };
+    }
+
+    public void onLandedUpon(World world, BlockState state, BlockPos pos, Entity entity, float fallDistance) {
+        entity.playSound(SoundEvents.BLOCK_HONEY_BLOCK_SLIDE, 1.0f, 1.0f);
+        if (!world.isClient) {
+            world.sendEntityStatus(entity, EntityStatuses.DRIP_RICH_HONEY);
+        }
+        if (entity.handleFallDamage(fallDistance, 0.2f, world.getDamageSources().fall())) {
+            entity.playSound(this.soundGroup.getFallSound(), this.soundGroup.getVolume() * 0.5f, this.soundGroup.getPitch() * 0.75f);
+        }
+    }
+
+    @Override
+    public void onEntityCollision(BlockState state, World world, BlockPos pos, Entity entity) {
+        if (isSliding(pos, entity)) {
+            triggerAdvancement(entity, pos);
+            updateSlidingVelocity(entity);
+            addCollisionEffects(world, entity);
+        }
+        super.onEntityCollision(state, world, pos, entity);
+    }
+
+    public static boolean isSliding(BlockPos pos, Entity entity) {
+        if (entity.isOnGround()) {
+            return false;
+        }
+        if (entity.getY() > (double)pos.getY() + 0.9375 - 1.0E-7) {
+            return false;
+        }
+        if (entity.getVelocity().y >= -0.08) {
+            return false;
+        }
+        double d = Math.abs((double)pos.getX() + 0.5 - entity.getX());
+        double e = Math.abs((double)pos.getZ() + 0.5 - entity.getZ());
+        double f = 0.4375 + (double)(entity.getWidth() / 2.0f);
+        return d + 1.0E-7 > f || e + 1.0E-7 > f;
+    }
+
+    public static void triggerAdvancement(Entity entity, BlockPos ignoredPos) {
+        if (entity instanceof ServerPlayerEntity && entity.getWorld().getTime() % 20L == 0L) {
+            Criteria.SLIDE_DOWN_BLOCK.trigger((ServerPlayerEntity)entity, Blocks.HONEY_BLOCK.getDefaultState());
+        }
+    }
+
+    public static void updateSlidingVelocity(Entity entity) {
+        Vec3d vec3d = entity.getVelocity();
+        if (vec3d.y < -0.13) {
+            double d = -0.05 / vec3d.y;
+            entity.setVelocity(new Vec3d(vec3d.x * d, -0.05, vec3d.z * d));
+        } else {
+            entity.setVelocity(new Vec3d(vec3d.x, -0.05, vec3d.z));
+        }
+        entity.onLanding();
+    }
+
+    public static void addCollisionEffects(World world, Entity entity) {
+        if (hasHoneyBlockEffects(entity)) {
+            if (world.random.nextInt(5) == 0) {
+                entity.playSound(SoundEvents.BLOCK_HONEY_BLOCK_SLIDE, 1.0f, 1.0f);
+            }
+            if (!world.isClient && world.random.nextInt(5) == 0) {
+                world.sendEntityStatus(entity, EntityStatuses.DRIP_HONEY);
+            }
+        }
+    }
+}

--- a/src/main/java/games/twinhead/moreslabsstairsandwalls/block/honey/HoneyStairs.java
+++ b/src/main/java/games/twinhead/moreslabsstairsandwalls/block/honey/HoneyStairs.java
@@ -1,0 +1,69 @@
+package games.twinhead.moreslabsstairsandwalls.block.honey;
+
+import games.twinhead.moreslabsstairsandwalls.block.ModBlocks;
+import games.twinhead.moreslabsstairsandwalls.block.translucent.TranslucentStairs;
+import net.minecraft.block.*;
+import net.minecraft.block.enums.BlockHalf;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityStatuses;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.world.BlockView;
+import net.minecraft.world.World;
+
+public class HoneyStairs extends TranslucentStairs {
+
+    protected static final VoxelShape TOP_SHAPE = HoneySlab.TOP_SHAPE;
+    protected static final VoxelShape BOTTOM_SHAPE = HoneySlab.BOTTOM_SHAPE;
+    protected static final VoxelShape BOTTOM_NORTH_WEST_CORNER_SHAPE = Block.createCuboidShape(1.0, 0.0, 1.0, 8.0, 8.0, 8.0);
+    protected static final VoxelShape BOTTOM_SOUTH_WEST_CORNER_SHAPE = Block.createCuboidShape(1.0, 0.0, 8.0, 8.0, 8.0, 15.0);
+    protected static final VoxelShape TOP_NORTH_WEST_CORNER_SHAPE = Block.createCuboidShape(1.0, 7.0, 1.0, 8.0, 15.0, 8.0);
+    protected static final VoxelShape TOP_SOUTH_WEST_CORNER_SHAPE = Block.createCuboidShape(1.0, 7.0, 8.0, 8.0, 15.0, 15.0);
+    protected static final VoxelShape BOTTOM_NORTH_EAST_CORNER_SHAPE = Block.createCuboidShape(8.0, 0.0, 1.0, 15.0, 8.0, 8.0);
+    protected static final VoxelShape BOTTOM_SOUTH_EAST_CORNER_SHAPE = Block.createCuboidShape(8.0, 0.0, 8.0, 15.0, 8.0, 15.0);
+    protected static final VoxelShape TOP_NORTH_EAST_CORNER_SHAPE = Block.createCuboidShape(8.0, 7.0, 1.0, 15.0, 15.0, 8.0);
+    protected static final VoxelShape TOP_SOUTH_EAST_CORNER_SHAPE = Block.createCuboidShape(8.0, 7.0, 8.0, 15.0, 15.0, 15.0);
+    protected static final VoxelShape[] TOP_SHAPES = composeShapes(TOP_SHAPE, BOTTOM_NORTH_WEST_CORNER_SHAPE, BOTTOM_NORTH_EAST_CORNER_SHAPE, BOTTOM_SOUTH_WEST_CORNER_SHAPE, BOTTOM_SOUTH_EAST_CORNER_SHAPE);
+    protected static final VoxelShape[] BOTTOM_SHAPES = composeShapes(BOTTOM_SHAPE, TOP_NORTH_WEST_CORNER_SHAPE, TOP_NORTH_EAST_CORNER_SHAPE, TOP_SOUTH_WEST_CORNER_SHAPE, TOP_SOUTH_EAST_CORNER_SHAPE);
+    private static final int[] SHAPE_INDICES = new int[]{12, 5, 3, 10, 14, 13, 7, 11, 13, 7, 11, 14, 8, 4, 1, 2, 4, 1, 2, 8};
+
+    public HoneyStairs(BlockState state, Settings settings) {
+        super(state, ModBlocks.HONEY_BLOCK, settings);
+    }
+
+    @Override
+    public VoxelShape getCollisionShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
+        VoxelShape[] shapes;
+        if (state.get(HALF) == BlockHalf.TOP) {
+            shapes = TOP_SHAPES;
+        } else {
+            shapes = BOTTOM_SHAPES;
+        }
+        return shapes[SHAPE_INDICES[this.getShapeIndexIndex(state)]];
+    }
+
+    private int getShapeIndexIndex(BlockState state) {
+        return state.get(SHAPE).ordinal() * 4 + state.get(FACING).getHorizontal();
+    }
+
+    public void onLandedUpon(World world, BlockState state, BlockPos pos, Entity entity, float fallDistance) {
+        entity.playSound(SoundEvents.BLOCK_HONEY_BLOCK_SLIDE, 1.0f, 1.0f);
+        if (!world.isClient) {
+            world.sendEntityStatus(entity, EntityStatuses.DRIP_RICH_HONEY);
+        }
+        if (entity.handleFallDamage(fallDistance, 0.2f, world.getDamageSources().fall())) {
+            entity.playSound(this.soundGroup.getFallSound(), this.soundGroup.getVolume() * 0.5f, this.soundGroup.getPitch() * 0.75f);
+        }
+    }
+
+    @Override
+    public void onEntityCollision(BlockState state, World world, BlockPos pos, Entity entity) {
+        if (HoneySlab.isSliding(pos, entity)) {
+            HoneySlab.triggerAdvancement(entity, pos);
+            HoneySlab.updateSlidingVelocity(entity);
+            HoneySlab.addCollisionEffects(world, entity);
+        }
+        super.onEntityCollision(state, world, pos, entity);
+    }
+}

--- a/src/main/java/games/twinhead/moreslabsstairsandwalls/block/honey/HoneyStairs.java
+++ b/src/main/java/games/twinhead/moreslabsstairsandwalls/block/honey/HoneyStairs.java
@@ -59,11 +59,29 @@ public class HoneyStairs extends TranslucentStairs {
 
     @Override
     public void onEntityCollision(BlockState state, World world, BlockPos pos, Entity entity) {
-        if (HoneySlab.isSliding(pos, entity)) {
+        if (isSliding(pos, entity)) {
             HoneySlab.triggerAdvancement(entity, pos);
             HoneySlab.updateSlidingVelocity(entity);
             HoneySlab.addCollisionEffects(world, entity);
         }
         super.onEntityCollision(state, world, pos, entity);
     }
+
+    private boolean isSliding(BlockPos pos, Entity entity) {
+        if (entity.isOnGround()) {
+            return false;
+        }
+        // would be more correct to use 0.4375 instead of 0.9375 depending on the side the entity is on
+        if (entity.getY() > (double)pos.getY() + 0.9375 - 1.0E-7) {
+            return false;
+        }
+        if (entity.getVelocity().y >= -0.08) {
+            return false;
+        }
+        double d = Math.abs((double)pos.getX() + 0.5 - entity.getX());
+        double e = Math.abs((double)pos.getZ() + 0.5 - entity.getZ());
+        double f = 0.4375 + (double)(entity.getWidth() / 2.0f);
+        return d + 1.0E-7 > f || e + 1.0E-7 > f;
+    }
+
 }

--- a/src/main/java/games/twinhead/moreslabsstairsandwalls/block/honey/HoneyWall.java
+++ b/src/main/java/games/twinhead/moreslabsstairsandwalls/block/honey/HoneyWall.java
@@ -2,10 +2,15 @@ package games.twinhead.moreslabsstairsandwalls.block.honey;
 
 import games.twinhead.moreslabsstairsandwalls.block.base.BaseWall;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.ShapeContext;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityStatuses;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
 
@@ -16,40 +21,40 @@ public class HoneyWall extends BaseWall {
     }
 
     public void onLandedUpon(World world, BlockState state, BlockPos pos, Entity entity, float fallDistance) {
-        if(!world.isClient())
-            if (entity.bypassesLandingEffects()) {
-                super.onLandedUpon(world, state, pos, entity, fallDistance);
-            } else {
-                entity.handleFallDamage(fallDistance, 0.0F, world.getDamageSources().fall());
-            }
-
-    }
-
-    public void onEntityLand(BlockView world, Entity entity) {
-            if (entity.bypassesLandingEffects()) {
-                super.onEntityLand(world, entity);
-            } else {
-                this.bounce(entity);
-            }
-
-    }
-
-    private void bounce(Entity entity) {
-        Vec3d vec3d = entity.getVelocity();
-        if (vec3d.y < 0.0) {
-            double d = entity instanceof LivingEntity ? 1.0 : 0.8;
-            entity.setVelocity(vec3d.x, -vec3d.y * d, vec3d.z);
+        entity.playSound(SoundEvents.BLOCK_HONEY_BLOCK_SLIDE, 1.0f, 1.0f);
+        if (!world.isClient) {
+            world.sendEntityStatus(entity, EntityStatuses.DRIP_RICH_HONEY);
         }
-
+        if (entity.handleFallDamage(fallDistance, 0.2f, world.getDamageSources().fall())) {
+            entity.playSound(this.soundGroup.getFallSound(), this.soundGroup.getVolume() * 0.5f, this.soundGroup.getPitch() * 0.75f);
+        }
     }
 
-    public void onSteppedOn(World world, BlockPos pos, BlockState state, Entity entity) {
-        double d = Math.abs(entity.getVelocity().y);
-        if (d < 0.1 && !entity.bypassesSteppingEffects()) {
-            double e = 0.4 + d * 0.2;
-            entity.setVelocity(entity.getVelocity().multiply(e, 1.0, e));
+    @Override
+    public void onEntityCollision(BlockState state, World world, BlockPos pos, Entity entity) {
+        if (isSliding(pos, entity)) {
+            HoneySlab.triggerAdvancement(entity, pos);
+            HoneySlab.updateSlidingVelocity(entity);
+            HoneySlab.addCollisionEffects(world, entity);
         }
+        super.onEntityCollision(state, world, pos, entity);
+    }
 
-        super.onSteppedOn(world, pos, state, entity);
+    private boolean isSliding(BlockPos pos, Entity entity) {
+        if (entity.isOnGround()) {
+            return false;
+        }
+        if (entity.getY() > (double)pos.getY() + 1.4375 - 1.0E-7) {
+            return false;
+        }
+        if (entity.getVelocity().y >= -0.08) {
+            return false;
+        }
+        VoxelShape shape = this.getCollisionShape(entity.getWorld().getBlockState(pos), entity.getWorld(), pos, ShapeContext.absent());
+        double entityRadius = entity.getWidth() / 2.0f;
+        return entity.getX() - entityRadius + 1.0E-7 > shape.getMax(Direction.Axis.X) ||
+                entity.getZ() - entityRadius + 1.0E-7 > shape.getMax(Direction.Axis.Z) ||
+                entity.getX() + entityRadius - 1.0E-7 < shape.getMin(Direction.Axis.X) ||
+                entity.getZ() + entityRadius - 1.0E-7 < shape.getMin(Direction.Axis.Z);
     }
 }

--- a/src/main/java/games/twinhead/moreslabsstairsandwalls/block/honey/HoneyWall.java
+++ b/src/main/java/games/twinhead/moreslabsstairsandwalls/block/honey/HoneyWall.java
@@ -1,0 +1,55 @@
+package games.twinhead.moreslabsstairsandwalls.block.honey;
+
+import games.twinhead.moreslabsstairsandwalls.block.base.BaseWall;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.BlockView;
+import net.minecraft.world.World;
+
+public class HoneyWall extends BaseWall {
+
+    public HoneyWall(Settings settings) {
+        super(settings);
+    }
+
+    public void onLandedUpon(World world, BlockState state, BlockPos pos, Entity entity, float fallDistance) {
+        if(!world.isClient())
+            if (entity.bypassesLandingEffects()) {
+                super.onLandedUpon(world, state, pos, entity, fallDistance);
+            } else {
+                entity.handleFallDamage(fallDistance, 0.0F, world.getDamageSources().fall());
+            }
+
+    }
+
+    public void onEntityLand(BlockView world, Entity entity) {
+            if (entity.bypassesLandingEffects()) {
+                super.onEntityLand(world, entity);
+            } else {
+                this.bounce(entity);
+            }
+
+    }
+
+    private void bounce(Entity entity) {
+        Vec3d vec3d = entity.getVelocity();
+        if (vec3d.y < 0.0) {
+            double d = entity instanceof LivingEntity ? 1.0 : 0.8;
+            entity.setVelocity(vec3d.x, -vec3d.y * d, vec3d.z);
+        }
+
+    }
+
+    public void onSteppedOn(World world, BlockPos pos, BlockState state, Entity entity) {
+        double d = Math.abs(entity.getVelocity().y);
+        if (d < 0.1 && !entity.bypassesSteppingEffects()) {
+            double e = 0.4 + d * 0.2;
+            entity.setVelocity(entity.getVelocity().multiply(e, 1.0, e));
+        }
+
+        super.onSteppedOn(world, pos, state, entity);
+    }
+}

--- a/src/main/java/games/twinhead/moreslabsstairsandwalls/block/translucent/TranslucentStairs.java
+++ b/src/main/java/games/twinhead/moreslabsstairsandwalls/block/translucent/TranslucentStairs.java
@@ -11,11 +11,36 @@ import net.minecraft.block.enums.BlockHalf;
 import net.minecraft.block.enums.SlabType;
 import net.minecraft.block.enums.StairShape;
 import net.minecraft.util.math.Direction;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.util.shape.VoxelShapes;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.stream.IntStream;
 
 public class TranslucentStairs extends BaseStairs {
 
     final @NotNull ModBlocks modBlock;
+
+    protected static VoxelShape[] composeShapes(VoxelShape base, VoxelShape northWest, VoxelShape northEast, VoxelShape southWest, VoxelShape southEast) {
+        return (VoxelShape[]) IntStream.range(0, 16).mapToObj(i -> composeShape(i, base, northWest, northEast, southWest, southEast)).toArray(VoxelShape[]::new);
+    }
+
+    protected static VoxelShape composeShape(int i, VoxelShape base, VoxelShape northWest, VoxelShape northEast, VoxelShape southWest, VoxelShape southEast) {
+        VoxelShape voxelShape = base;
+        if ((i & 1) != 0) {
+            voxelShape = VoxelShapes.union(voxelShape, northWest);
+        }
+        if ((i & 2) != 0) {
+            voxelShape = VoxelShapes.union(voxelShape, northEast);
+        }
+        if ((i & 4) != 0) {
+            voxelShape = VoxelShapes.union(voxelShape, southWest);
+        }
+        if ((i & 8) != 0) {
+            voxelShape = VoxelShapes.union(voxelShape, southEast);
+        }
+        return voxelShape;
+    }
 
     public TranslucentStairs(BlockState blockState, @NotNull ModBlocks block, Settings settings) {
         super(blockState, settings);

--- a/src/main/java/games/twinhead/moreslabsstairsandwalls/registry/ModRegistry.java
+++ b/src/main/java/games/twinhead/moreslabsstairsandwalls/registry/ModRegistry.java
@@ -17,6 +17,9 @@ import games.twinhead.moreslabsstairsandwalls.block.dirt.*;
 import games.twinhead.moreslabsstairsandwalls.block.falling.FallingSlab;
 import games.twinhead.moreslabsstairsandwalls.block.falling.FallingStairs;
 import games.twinhead.moreslabsstairsandwalls.block.falling.FallingWall;
+import games.twinhead.moreslabsstairsandwalls.block.honey.HoneySlab;
+import games.twinhead.moreslabsstairsandwalls.block.honey.HoneyStairs;
+import games.twinhead.moreslabsstairsandwalls.block.honey.HoneyWall;
 import games.twinhead.moreslabsstairsandwalls.block.ice.IceSlab;
 import games.twinhead.moreslabsstairsandwalls.block.ice.IceStairs;
 import games.twinhead.moreslabsstairsandwalls.block.leaves.LeavesSlab;
@@ -269,6 +272,10 @@ public class ModRegistry {
                         (block.hasSlab ? new SlimeSlab(block.getSettings()) : null),
                         (block.hasStairs ? new SlimeStairs(block.parentBlock.getDefaultState(), block.getSettings()) : null),
                         (block.hasWall ? new SlimeWall(block.getSettings()) : null));
+                case HONEY_BLOCK -> registerBlock(block,
+                        (block.hasSlab ? new HoneySlab(block.getSettings()) : null),
+                        (block.hasStairs ? new HoneyStairs(block.parentBlock.getDefaultState(), block.getSettings()) : null),
+                        (block.hasWall ? new HoneyWall(block.getSettings()) : null));
                 case REDSTONE_BLOCK -> registerBlock(block,
                         (block.hasSlab ? new RedstoneSlab(block.getSettings()) : null),
                         (block.hasStairs ? new RedstoneStairs(block.parentBlock.getDefaultState(), block.getSettings()) : null),


### PR DESCRIPTION
I noticed that you could run and jump like normal on honey slabs/stairs/walls, while you can't on vanilla honey blocks.
That was easily fixed by the 2 lines in ModBlocks.java

The sticky-sliding on the sides of honey blocks was also missing.
To implement that, I had to add HoneySlab, HoneyStairs and HoneyWall