### PR TITLE
removed cullface from some slab model faces to fix sodium issue

### DIFF
--- a/src/main/resources/assets/more_slabs_stairs_and_walls/models/block/dirt_path_slab.json
+++ b/src/main/resources/assets/more_slabs_stairs_and_walls/models/block/dirt_path_slab.json
@@ -16,7 +16,7 @@
 				"east": {"uv": [0, 1, 16, 7], "texture": "#side", "cullface": "east"},
 				"south": {"uv": [0, 1, 16, 7], "texture": "#side", "cullface": "south"},
 				"west": {"uv": [0, 1, 16, 7], "texture": "#side", "cullface": "west"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#top", "cullface": "up", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#top", "tintindex": 0},
 				"down": {"uv": [0, 0, 16, 16], "texture": "#bottom", "cullface": "down"}
 			}
 		}

--- a/src/main/resources/assets/more_slabs_stairs_and_walls/models/block/dirt_path_slab_top.json
+++ b/src/main/resources/assets/more_slabs_stairs_and_walls/models/block/dirt_path_slab_top.json
@@ -16,7 +16,7 @@
 				"south": {"uv": [0, 1, 16, 9], "texture": "#side", "cullface": "south"},
 				"west": {"uv": [0, 1, 16, 9], "texture": "#side", "cullface": "west"},
 				"up": {"uv": [0, 0, 16, 16], "texture": "#top", "cullface": "up", "tintindex": 0},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#bottom", "cullface": "down"}
+				"down": {"uv": [0, 0, 16, 16], "texture": "#bottom"}
 			}
 		}
 	]

--- a/src/main/resources/assets/more_slabs_stairs_and_walls/models/block/glazed_terracotta_slab_top.json
+++ b/src/main/resources/assets/more_slabs_stairs_and_walls/models/block/glazed_terracotta_slab_top.json
@@ -15,7 +15,7 @@
         "south": {"uv": [8, 16, 16, 0], "rotation": 90, "texture": "#all", "cullface": "south"},
         "west": {"uv": [0, 8, 16, 16], "texture": "#all", "cullface": "west"},
         "up": {"uv": [0, 0, 16, 16], "texture": "#all", "cullface": "up"},
-        "down": {"uv": [0, 0, 16, 16], "texture": "#all", "cullface": "down"}
+        "down": {"uv": [0, 0, 16, 16], "texture": "#all"}
       }
     }
   ],

--- a/src/main/resources/assets/more_slabs_stairs_and_walls/models/block/honey_block_slab.json
+++ b/src/main/resources/assets/more_slabs_stairs_and_walls/models/block/honey_block_slab.json
@@ -22,7 +22,7 @@
             "to": [ 16, 8, 16],
             "faces": {
                 "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom", "cullface": "down" },
-                "up":    { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom", "cullface": "up" },
+                "up":    { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom" },
                 "north": { "uv": [ 0, 0, 16, 8 ], "texture": "#bottom", "cullface": "north" },
                 "south": { "uv": [ 0, 0, 16, 8 ], "texture": "#bottom", "cullface": "south" },
                 "west":  { "uv": [ 0, 0, 16, 8 ], "texture": "#bottom", "cullface": "west" },

--- a/src/main/resources/assets/more_slabs_stairs_and_walls/models/block/honey_block_slab_top.json
+++ b/src/main/resources/assets/more_slabs_stairs_and_walls/models/block/honey_block_slab_top.json
@@ -21,7 +21,7 @@
         {   "from": [ 0, 8, 0 ],
             "to": [ 16, 16, 16],
             "faces": {
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom", "cullface": "down" },
+                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom" },
                 "up":    { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom", "cullface": "up" },
                 "north": { "uv": [ 0, 0, 16, 8 ], "texture": "#bottom", "cullface": "north" },
                 "south": { "uv": [ 0, 0, 16, 8 ], "texture": "#bottom", "cullface": "south" },

--- a/src/main/resources/assets/more_slabs_stairs_and_walls/models/block/template_grass_slab.json
+++ b/src/main/resources/assets/more_slabs_stairs_and_walls/models/block/template_grass_slab.json
@@ -18,7 +18,7 @@
 				"east": {"uv": [0, 0, 16, 8], "texture": "#side", "cullface": "east"},
 				"south": {"uv": [0, 0, 16, 8], "texture": "#side", "cullface": "south"},
 				"west": {"uv": [0, 0, 16, 8], "texture": "#side", "cullface": "west"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#top", "cullface": "up", "tintindex": 0},
+				"up": {"uv": [0, 0, 16, 16], "texture": "#top", "tintindex": 0},
 				"down": {"uv": [0, 0, 16, 16], "texture": "#bottom", "cullface": "down"}
 			}
 		},

--- a/src/main/resources/assets/more_slabs_stairs_and_walls/models/block/template_grass_slab_top.json
+++ b/src/main/resources/assets/more_slabs_stairs_and_walls/models/block/template_grass_slab_top.json
@@ -18,7 +18,7 @@
 				"south": {"uv": [0, 0, 16, 8], "texture": "#side", "cullface": "south"},
 				"west": {"uv": [0, 0, 16, 8], "texture": "#side", "cullface": "west"},
 				"up": {"uv": [0, 0, 16, 16], "texture": "#top", "cullface": "up", "tintindex": 0},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#bottom", "cullface": "down"}
+				"down": {"uv": [0, 0, 16, 16], "texture": "#bottom"}
 			}
 		},
 		{


### PR DESCRIPTION
Noticed graphical issues similar to Issue #11 that occurs with Sodium:
![2023-10-29_11 23 00](https://github.com/Nibaru/More-Slabs-Stairs-and-Walls/assets/80597173/4839d3ae-c94e-4b01-9a0e-7eedf0e3016a)

Removing the "up"-cullface from bottom-slabs and the "bottom"-cullface from top-slabs fixed the issues.
It looks like those cullfaces had already been removed (or never added?) from some slab models, just not all of them